### PR TITLE
fix: change implementation to js-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "blurhash": "^1.1.5",
     "pull-stream": "^3.6.14",
-    "sharp": "^0.30.7"
+    "jimp": "0.16.1"
   },
   "prettier": {
     "semi": false,

--- a/test/index.js
+++ b/test/index.js
@@ -68,7 +68,7 @@ test('generate produces a valid blurhash hash', (t) => {
           t.ok(isBlurhashValid(hash), 'valid blurhash created')
           t.equal(componentX, 4, 'correct componentX')
           t.equal(componentY, 4, 'correct componentY')
-          t.equal(hash, 'UELpw400_3_2+G?Ht7t7]l~qD%D%D4jGtRM_', 'correct hash')
+          t.equal(hash, 'UEL:=p00~q~q:*?Hx]t7;2_39Y8_HXV@x]M_', 'correct hash')
 
           sbot.close(true, t.end)
         }
@@ -96,7 +96,7 @@ test('generate handles horizontal rectangle', (t) => {
           t.equal(componentY, 4, 'correct componentY')
           t.equal(
             hash,
-            'W:IE;QRPRltRkCjZ?dR*bHogj[jsI?o#oeV@WBoLRjbJaeWAWBoe',
+            'W:I5PqRPRltRofjs?dR*bHogj[jsNKo#oeV@WBoLRjbJaeWAWBoe',
             'correct hash'
           )
 
@@ -126,7 +126,7 @@ test('generate handles vertical rectangle', (t) => {
           t.equal(componentY, 6, 'correct componentY')
           t.equal(
             hash,
-            'mbENCvXBH=od_4afX9o#^+R*S5of.9R+RPof$_WBkDWV-.WCRkae',
+            'mbEN9nXBH=oc_4afX9o#^+R*S5of.9R+RPof$_WBf,WV-.WCRkae',
             'correct hash'
           )
 


### PR DESCRIPTION
## Context

I was trying to put this library in Manyverse such that it compiles for mobile. This means compiling `sharp` as a node.js native module. 

## Problem

I've done this a few times with `leveldown-nodejs-mobile` and `sodium-native-nodejs-mobile`, but `sharp` uses `libvips` under the hood, and the configuration scripts to get `libvips` are ... complex. Creating `sharp-nodejs-mobile` is possible, but it seems more effort than (e.g.) `leveldown-nodejs-mobile`, and at this point I wasn't sure about the cost-benefit ratio, given that this library is just about blurring images, not the critically important cannot-not-have leveldown and sodium-native.

## Solution

I took a quick look at the state of npm libraries out there for image manipulation, written in pure JS. It's not that bad. I found `jimp` and `image-js`, with similar API as `sharp`. Then I tried out using them, and the results are... workable. In terms of blurhash quality, there's no problem at all. Obviously, performance is the biggest issue.

I implemented ssb-blobs-blurhash with the two JS alternatives and here are the perf results

```
## small image

  48945 bytes
  540x486

## large image

  4963017 bytes
  3480x2160

## sharp

    bundlephobia: 85kB minified

    small.jpg: 33.109ms
    large.jpg: 101.802ms

## jimp

    bundlephobia: 350kB minified

    small.jpg: 91.926ms
    large.jpg: 1576.508ms

## image-js

    bundlephobia: 384kB minified

    small.jpg: 167.755ms
    large.jpg: 2251.008ms
```

**jimp** seems to be an easy winner, both in bundle size and CPU performance. I think making the user wait for 1.5sec to process a 4.7MB image is... not a showstopper. It's not great, but we can work with it. More importantly, most of the time we're not going to be handling 4.7MB images, we're going to be handling 150kB profile images, so we can expect that processing times are ~300ms, which is not good but it's not bad either. 

The ideal solution is to use `sharp`, indeed, but this is something we can improve in the future once the cost/benefit ratio for that endeavor makes sense. Currently, it wouldn't make sense to even use ssb-blobs-blurhash on mobile if we have to spend several days (weeks?) getting it to compile properly.